### PR TITLE
fix typifying arrays with existing brackets

### DIFF
--- a/src/PineTypify.ts
+++ b/src/PineTypify.ts
@@ -103,7 +103,7 @@ export class PineTypify {
           if (lineText.startsWith('//')) {
             continue
           }
-          if (RegExp(`\\b(${type}|\\[\\])\\s+${name}\\b`, 'g').test(lineText)) {
+          if (RegExp(`\\b(${type}|\\s*\\[\\])\\s+${name}\\b`, 'g').test(lineText)) {
             continue
           }
           // Check and replace array type notation


### PR DESCRIPTION
Hello,

Thanks for the great extension! I found a bug when typifying, if an array is defined like `int []` with spaces between the type and the brackets, typifying it erroneously adds `array<int>`. For example:

<img width="472" alt="Screenshot 2024-06-05 at 11 46 23 PM" src="https://github.com/frizLabz-FFriZz/Pine-Script-v5-VS-Code/assets/20136533/dac3469e-b52c-4941-973f-07ec5ecdae3d">

<img width="564" alt="Screenshot 2024-06-05 at 11 46 50 PM" src="https://github.com/frizLabz-FFriZz/Pine-Script-v5-VS-Code/assets/20136533/70095089-78d7-4b29-9664-44bd32f30ef4">

This PR fixes the issue by allowing 0 or more whitespaces before the brackets in the regex.


